### PR TITLE
chore(makefile): added default makefile from internet

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,15 @@
+APP_EXECUTABLE=a7
+
+build:
+ GOARCH=amd64 GOOS=darwin go build -o ${APP_EXECUTABLE}-darwin main.go
+ GOARCH=amd64 GOOS=linux go build -o ${APP_EXECUTABLE}-linux main.go
+ GOARCH=amd64 GOOS=windows go build -o ${APP_EXECUTABLE}-windows main.go
+
+run: build
+ ./${APP_EXECUTABLE}
+
+clean:
+ go clean
+ rm ${APP_EXECUTABLE}-darwin
+ rm ${APP_EXECUTABLE}-linux
+ rm ${APP_EXECUTABLE}-windows


### PR DESCRIPTION
This PR adds a default makefile from https://www.mohitkhare.com/blog/go-makefile/, will expand on it later.