### PR TITLE
fix(keymapping): Fixed odd keymapping where q would quit the app

### DIFF
--- a/ui/app.go
+++ b/ui/app.go
@@ -169,7 +169,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.screen = screenDashboard
 				return m, nil
 			}
-		case "q", "ctrl+c":
+		case "ctrl+c":
 			return m, tea.Quit
 		case "enter":
 			if m.screen == screenSetup {


### PR DESCRIPTION
This PR patches the keymapping, removing `q` from being one of the keys that quits the app. Not sure what I was thinking having both `ctrl+c` and `q` be the quit functionality.