### PR TITLE
fix(dashboard-metadata): fixes for dashboard metadata

### DIFF
--- a/ui/app/app.go
+++ b/ui/app/app.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"time"
+
 	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
@@ -335,10 +337,6 @@ func (m AppModel) updateDashboardSelection() AppModel {
 		m.dashboard.SelectedNote = nil
 		m.dashboard.SelectedErr = nil
 		m.dashboard.SelectedFilename = ""
-		return m
-	}
-
-	if noteItem.Info.Filename == m.dashboard.SelectedFilename && m.dashboard.SelectedErr == nil && m.dashboard.SelectedNote != nil {
 		return m
 	}
 

--- a/ui/app/app.go
+++ b/ui/app/app.go
@@ -1,8 +1,6 @@
 package app
 
 import (
-	"time"
-
 	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
@@ -319,16 +317,16 @@ func (m AppModel) applyDashboardNotes(msg dashboardNotesMsg) AppModel {
 		m.dashboard.List.Select(0)
 	}
 	m = m.updateDashboardListSize()
-	m = m.updateDashboardSelection()
+	m.updateDashboardSelection()
 	return m
 }
 
-func (m AppModel) updateDashboardSelection() AppModel {
+func (m *AppModel) updateDashboardSelection() {
 	if m.config.StoragePath == "" {
 		m.dashboard.SelectedNote = nil
 		m.dashboard.SelectedErr = nil
 		m.dashboard.SelectedFilename = ""
-		return m
+		return
 	}
 
 	item := m.dashboard.List.SelectedItem()
@@ -337,7 +335,7 @@ func (m AppModel) updateDashboardSelection() AppModel {
 		m.dashboard.SelectedNote = nil
 		m.dashboard.SelectedErr = nil
 		m.dashboard.SelectedFilename = ""
-		return m
+		return
 	}
 
 	service := journal.NewService(m.config.StoragePath, journal.WithEncryption(m.config.Encrypt, m.config.SshKeyPath))
@@ -345,7 +343,6 @@ func (m AppModel) updateDashboardSelection() AppModel {
 	m.dashboard.SelectedFilename = noteItem.Info.Filename
 	m.dashboard.SelectedNote = note
 	m.dashboard.SelectedErr = err
-	return m
 }
 
 func (m AppModel) View() string {

--- a/ui/app/models.go
+++ b/ui/app/models.go
@@ -41,6 +41,7 @@ type DashboardModel struct {
 	SelectedNote     *journal.Note
 	SelectedErr      error
 	SelectedFilename string
+	SelectedModTime  time.Time
 }
 
 type ViewerModel struct {


### PR DESCRIPTION
This PR fixes an issue with the dashboard, journal metadata where we were only loading a single note's state. This PR also fixes a couple of niggles where we changed the name of the file in the journal list on the left to be the "title" rather than the file name, and oddly displayed the filename in the journal metadata...