### PR TITLE
chore(fix-up-makefile): Removed windows build support

### DIFF
--- a/makefile
+++ b/makefile
@@ -3,7 +3,6 @@ APP_EXECUTABLE=a7
 build:
 	GOARCH=amd64 GOOS=darwin go build -o ${APP_EXECUTABLE}-darwin main.go
 	GOARCH=amd64 GOOS=linux go build -o ${APP_EXECUTABLE}-linux main.go
-	GOARCH=amd64 GOOS=windows go build -o ${APP_EXECUTABLE}-windows main.go
 
 run: build
 	./${APP_EXECUTABLE}
@@ -12,4 +11,3 @@ clean:
 	go clean
 	rm ${APP_EXECUTABLE}-darwin
 	rm ${APP_EXECUTABLE}-linux
-	rm ${APP_EXECUTABLE}-windows


### PR DESCRIPTION
This PR removes the build support for windows for the time being.